### PR TITLE
chore: remove unused import

### DIFF
--- a/src/mprView.js
+++ b/src/mprView.js
@@ -4,7 +4,7 @@ import vtkInteractorStyleMPRSlice from "./vtk/vtkInteractorMPRSlice";
 
 import { quat, vec3, mat4 } from "gl-matrix";
 
-import { degrees2radians, fill2DView } from "./utils/utils";
+import { degrees2radians } from "./utils/utils";
 import { baseView } from "./baseView";
 
 /**


### PR DESCRIPTION
this is causing errors when building with node 20 and upgraded env
<img width="787" alt="image" src="https://github.com/user-attachments/assets/a42559da-9d2f-416f-be9f-bd726a81b4bf" />
